### PR TITLE
xargs to strip new lines from cat of injection-flags 

### DIFF
--- a/coq-shim/with-tactician.in
+++ b/coq-shim/with-tactician.in
@@ -14,6 +14,7 @@ TACTICIANDIR=%{coq:lib}%/user-contrib/Tactician
 
 TACTICIANEXTRAFLAGS=$(cat %{coq-tactician:etc}%/injection-flags) # Old location, to be removed
 TACTICIANEXTRAFLAGS="$TACTICIANEXTRAFLAGS $(for f in %{coq-tactician:share}%/plugins/*/injection-flags; do (cat $f; printf ' '); done)"
+TACTICIANEXTRAFLAGS=$(echo $TACTICIANEXTRAFLAGS | xargs)
 TACTICIANFLAGS="-q -I $TACTICIANDIR -R $TACTICIANDIR Tactician -rifrom Tactician Ltac1.Record"
 
 link_binary() {


### PR DESCRIPTION
fixing the bug coming from concatenation of injection-flags terminating with a newline and consequently resulting in the wrong wrapper script in which options are written on several lines 