### PR TITLE
Subst patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ _build/
 # Local OPAM switch
 _opam/
 opam
+
+# Emacs
+.emacs.desktop

--- a/coq-shim/tactician-patch.in
+++ b/coq-shim/tactician-patch.in
@@ -13,7 +13,7 @@ patch() {
     echo "Package patched!"
 }
 
-TACTICIANLIB=%{coq-tactician:share}%
+TACTICIANLIB="%{share}%/coq-tactician"
 PACKAGE="$1"; shift
 VERSION="$1"; shift
 

--- a/coq-shim/with-tactician.in
+++ b/coq-shim/with-tactician.in
@@ -9,11 +9,11 @@ then
 fi
 
 OPAMBIN=%{bin}%
-TACTICIANLIB=%{coq-tactician:lib}%
+TACTICIANLIB=%{lib}%/coq-tactician
 TACTICIANDIR=%{coq:lib}%/user-contrib/Tactician
 
-TACTICIANEXTRAFLAGS=$(cat %{coq-tactician:etc}%/injection-flags) # Old location, to be removed
-TACTICIANEXTRAFLAGS="$TACTICIANEXTRAFLAGS $(for f in %{coq-tactician:share}%/plugins/*/injection-flags; do (cat $f; printf ' '); done)"
+TACTICIANEXTRAFLAGS=$(cat %{etc}%/coq-tactician/injection-flags) # Old location, to be removed
+TACTICIANEXTRAFLAGS="$TACTICIANEXTRAFLAGS $(for f in %{share}%/coq-tactician/plugins/*/injection-flags; do (cat $f; printf ' '); done)"
 TACTICIANEXTRAFLAGS=$(echo $TACTICIANEXTRAFLAGS | xargs)
 TACTICIANFLAGS="-q -I $TACTICIANDIR -R $TACTICIANDIR Tactician -rifrom Tactician Ltac1.Record"
 

--- a/coq-tactician.opam
+++ b/coq-tactician.opam
@@ -59,5 +59,4 @@ tags: [
 substs: [
   "coq-shim/with-tactician"
   "coq-shim/tactician-patch"
-  "src/tactician.ml"
 ]

--- a/src/dune
+++ b/src/dune
@@ -68,13 +68,16 @@
    coq-tactician.record-plugin
  )
 )
-(rule
- (targets tactician.ml)
- ; When installed through opam, we perform substitutions through the 'substs' directive in the opam file.
- ; It also works using this rule, but running opam during an installation can be risky due to sandboxing issues.
- (mode fallback)
- (deps tactician.ml.in)
- (action (run opam config subst %{targets})))
+
+; scheduled to remove
+;(rule
+; (targets tactician.ml)
+; ; When installed through opam, we perform substitutions through the 'substs' directive in the opam file.
+; ; It also works using this rule, but running opam during an installation can be risky due to sandboxing issues.
+; (mode fallback)
+; (deps tactician.ml.in)
+; (action (run opam config subst %{targets})))
+
 (executable
  (name tactician)
  (package coq-tactician)
@@ -84,5 +87,6 @@
  (libraries
    unix
    opam-client
+   findlib
  )
 )

--- a/src/tactician.ml
+++ b/src/tactician.ml
@@ -4,6 +4,8 @@ open Cmdliner
 
 let coqrc_string = "From Tactician Require Import Ltac1.\n"
 
+let coq_tactician_lib = Findlib.package_directory "coq-tactician"
+
 let syscall cmd =
   let ic, oc = Unix.open_process cmd in
   let buf = Buffer.create 16 in
@@ -154,8 +156,12 @@ let config_add_remove gt ?st name value =
 (* TODO: Remove old commands once enough time has elapsed *)
 let old_wrap_command = "[\"with-tactician\"] {coq-tactician:installed}"
 let old_pre_build_command = "[\"tactician-patch\" name version] {coq-tactician:installed}"
-let wrap_command = "[\"%{coq-tactician:lib}%/with-tactician\"] {coq-tactician:installed}"
-let pre_build_command = "[\"%{coq-tactician:lib}%/tactician-patch\" name version] {coq-tactician:installed}"
+let wrap_command = "[\"" ^ coq_tactician_lib ^ "/with-tactician\"] {coq-tactician:installed}"
+let pre_build_command = "[\"" ^ coq_tactician_lib ^ "/tactician-patch\" name version] {coq-tactician:installed}"
+
+let () =
+  prerr_endline pre_build_command
+
 
 let inject () =
   opam_init_no_lock @@ fun gt ->
@@ -203,7 +209,7 @@ let stdlib () =
   `Ok ()
 
 let exec_command cmd args =
-  let wt = "%{coq-tactician:lib}%/with-tactician" in
+  let wt = coq_tactician_lib ^ "/with-tactician" in
   Unix.execv wt (Array.of_list (wt::cmd::args))
 
 (* Command line interface *)


### PR DESCRIPTION
there is issue with dune build of coq-tactician on a clean system that doesn't have opam variable coq-tactician:lib defined

this patch 
- uses findlib.package_directory in compiled tactician.ml instead of subst
- uses better defined opam variables in shell script templates (those that exists if package is not yet installed)
