### PR TITLE
Fast features

### DIFF
--- a/src/features.ml
+++ b/src/features.ml
@@ -61,7 +61,7 @@ module F (TS: TacticianStructures) = struct
     | TInt n -> Uint63.hash n
     | TFloat n -> Float64.hash n
 
-  let term_sexpr_to_simple_features2
+  let term_sexpr_to_simple_features
       ~gen_feat:(init, comb)
       ~store_feat:(empty, add)
       maxlength (oterm : Constr.t) =
@@ -128,7 +128,7 @@ module F (TS: TacticianStructures) = struct
     let goal = proof_state_goal ps in
     let mkfeats t acc =
       let x = term_repr t in
-      term_sexpr_to_simple_features2
+      term_sexpr_to_simple_features
         ~gen_feat
         ~store_feat:(acc, add) max_length x in
     (* TODO: distinquish goal features from hyp features *)
@@ -136,7 +136,7 @@ module F (TS: TacticianStructures) = struct
     mkfeats goal acc
 
   let context_simple_ints ctx =
-    let mkfeats t = term_sexpr_to_simple_features2
+    let mkfeats t = term_sexpr_to_simple_features
         ~gen_feat:(simple_token_to_int, Hashset.Combine.combine)
         ~store_feat:(Int.Set.empty, (fun a b -> Int.Set.add b a))
         2 (term_repr t) in

--- a/src/features.ml
+++ b/src/features.ml
@@ -4,22 +4,10 @@ open Learner_helper
 open Names
 
 type feat_kind = Struct | Seman | Verti
-type 'a semantic_features = { interm: 'a list list; acc: 'a list}
-(*for `f(g(a), b)` and go to `a`
-  walk: the walk from root to `a`
-  walk_to_sibiling: walk from root to f such that we can calculate the walk to `b` basing on it*)
-type ('a, 'b) vertical_features =
-  { walk : 'a
-  ; acc : 'b list}
 type ('a, 'b, 'c, 'd) features =
-  { semantic : 'a semantic_features
+  { semantic : 'a list list
   ; structure : 'b
-  ; vertical: ('c, 'd) vertical_features }
-
-type ('a, 'b, 'c, 'd) features2 =
-  { semantic2 : 'a list list
-  ; structure2 : 'b
-  ; vertical2 : 'c
+  ; vertical : 'c
   ; store : 'd }
 
 let global2s g =
@@ -281,161 +269,7 @@ module F (TS: TacticianStructures) = struct
         2 ps in
     CString.Set.elements feats
 
-  let rep_elem n elem =
-    let rec rep_elem_aux acc n elem =
-      if n = 0 then acc else rep_elem_aux (elem :: acc) (n-1) elem
-    in
-    rep_elem_aux [] n elem
-
-  let warn lterm oterm =
-    Feedback.msg_warning (Pp.str ("Tactician did not know how to handle something. Please report. "
-                                  ^ sexpr_to_string lterm ^ " : " ^sexpr_to_string oterm))
-  let term_sexpr_to_complex_features maxlength oterm =
-    let atomtypes = ["Evar"; "Rel"; "Construct"; "Ind"; "Const"; "Var"; "Int"; "Float"] in
-    let is_atom nodetype = List.exists (String.equal nodetype) atomtypes in
-    let atom_to_string atomtype content = match atomtype, content with
-      | "Rel", _ -> "R"
-      | "Evar", (Leaf _ :: _) -> "E"
-      | "Var", Leaf c :: _ -> "$" ^ c
-      | "Construct", Leaf c :: _
-      | "Ind", Leaf c :: _
-      | "Const", Leaf c :: _ -> c
-      | "Int", Leaf c :: _ -> "i" ^ c
-      | "Float", Leaf c :: _ -> "f" ^ c
-      | _, _ -> warn (Leaf "KAK") oterm; "*"
-    in
-    (* for a tuple `(interm, acc)`:
-       - `interm` is an intermediate list of list of features that are still being assembled
-         invariant: `forall i ls, 0<i<=maxlength -> In ls (List.nth (i - 1)) -> List.length ls = i`
-       - `acc`: accumulates features that are fully assembled *)
-    let add_atom atomtype content features =
-      let interm, acc = features.semantic.interm, features.semantic.acc in
-      let atom = atom_to_string atomtype content in
-      (* `interm` contains term tree walks to maximal depth, maximal depth - 1,..., 1 *)
-      let interm' = [[atom]] :: List.map (List.map (fun fs -> atom::fs)) interm in
-      (* Remove the last item to keep the maximal depth constraint.
-        The length of `interm` = the maximal depth constraint.
-        The initial `interm` is [[walk],[],...,[]]; thus, `removelast` will remove [] in the beginning *)
-      {interm = removelast interm'; acc = List.flatten interm' @ acc}
-    in
-    let set_interm features x = {features with semantic = {features.semantic with interm = x}} in
-    let set_walk features x = {features with vertical = {features.vertical with walk = x}} in
-    let start = replicate [] (maxlength - 1) in
-    let init_features = {semantic = {interm = replicate [] (maxlength - 1); acc = []} ;
-      structure = []; vertical = {walk = []; acc = []}} in
-    let reset_interm features = set_interm features start in
-    let start_structure features role =
-      {features with structure = features.structure @ ["(" ; role]}
-    in
-    let end_structure features =
-       {features with structure = features.structure @ [")"] }
-    in
-    let verti_atom atomtype content features role =
-      if List.length features.vertical.walk == 1 then
-        features
-      else
-        let atom_with_role = (atom_to_string atomtype content) ^":"^role in
-        {features with vertical = {
-          features.vertical with acc =
-          (features.vertical.walk@[atom_with_role]) :: features.vertical.acc
-        }}
-    in
-    let calculate_vertical_features term role features =
-      match term with
-      | Node (Leaf nt :: ls ) when is_atom nt ->
-        let features' = verti_atom nt ls features role in
-        features'
-      | _ ->
-        {features with vertical = {
-          features.vertical with walk = (features.vertical.walk@[role])}}
-    in
-    let rec aux_reset features (term, role) depth walk =
-      let reset_features = reset_interm features in
-      let reset_features = set_walk reset_features walk in
-      let features' = aux reset_features term role depth in
-      reset_interm features'
-    and aux_reset_fold features term_role_pairs depth =
-      let walk = features.vertical.walk in
-      let next_level_depth = depth + 1 in
-      List.fold_left (fun features' term_role_pair->
-        aux_reset features' term_role_pair next_level_depth walk) features term_role_pairs 
-    and aux features term role depth =
-      let features = calculate_vertical_features term role features in
-      let features = match term with
-        (* Interesting leafs *)
-        | Node (Leaf nt :: ls) when is_atom nt ->
-          if depth > 2 then
-            {features with semantic = add_atom nt ls features}
-          else
-            {semantic = add_atom nt ls features;
-            structure = features.structure @ ["X"];
-            vertical = features.vertical}
-        (* Uninteresting leafs *)
-        | Node (Leaf "Sort" :: _)
-        | Node (Leaf "Meta" :: _) -> features
-        (* Recursion for grammar we don't handle *)
-        | Node [Leaf "LetIn"; _id; _; body1; typ; body2] ->
-          let roles = ["LetVarBody"; "LetVarType"; "LetBody"] in
-          end_structure (aux_reset_fold (start_structure features "LetIn")
-          (List.combine [body1; typ; body2] roles) depth)
-        | Node (Leaf "Case" :: _ :: term :: typ :: cases) ->
-          let roles = (["MatchTerm"; "MatchTermType"] @ (rep_elem (List.length cases) "Case")) in
-          end_structure (aux_reset_fold (start_structure features "Case")
-          (List.combine (term::typ::cases) roles) depth)
-        | Node [Leaf "Fix"; _; Node types; Node terms] ->
-          let roles = (rep_elem (List.length terms) "FixTerm") @ (rep_elem (List.length types) "FixType") in
-          end_structure (aux_reset_fold (start_structure features "Fix") (List.combine (terms @ types) roles) depth)
-        | Node [Leaf "CoFix"; _ ; Node types; Node terms] ->
-          let roles = (rep_elem (List.length terms) "CoFixTerm") @ (rep_elem (List.length types) "CoFixType") in
-          end_structure (aux_reset_fold (start_structure features "CoFix") (List.combine (terms @ types) roles) depth)
-        | Node [Leaf "Prod"  ; _; _; typ; body] ->
-          let roles = ["ProdType"; "ProdBody"] in
-          end_structure(aux_reset_fold (start_structure features "Prod") (List.combine [typ; body] roles) depth)
-        | Node [Leaf "Lambda"; _; _; typ; body] ->
-          let roles = ["LambdaType"; "LambdaBody"] in
-          end_structure(aux_reset_fold (start_structure features "Lambda") (List.combine [typ; body] roles) depth)
-        (* The golden path *)
-        | Node [Leaf "Proj"; p; term] ->
-          let features' = start_structure {features with semantic = add_atom "Const" [p] features} "Proj"
-          in end_structure (aux features' term "ProjTerm" (depth + 1))
-        | Node (Leaf "App" :: head :: args) ->
-          let walk = features.vertical.walk in
-          let arg_num = List.length args in
-          let features_with_head = aux (start_structure features "App") head "AppFun" (depth + 1) in
-          let features_with_head_and_arg_num =
-            {features_with_head with structure = features_with_head.structure @ [Stdlib.string_of_int arg_num]} in
-          let feature' = List.fold_left (fun features arg ->
-            let features = set_walk features walk in
-            let features_this_arg = aux features arg "AppArg" (depth + 1) in
-            (* We reset back to `interm` of `features_with_head_and_arg_num` for every arg *)
-            set_interm features_this_arg features_with_head_and_arg_num.semantic.interm)
-            features_with_head_and_arg_num args
-          in
-          end_structure(reset_interm feature')
-        | Node [Leaf "Cast"; term; _; typ] ->
-          (* We probably want to have the type of the cast, but isolated *)
-          let features_reset = reset_interm features in
-          let features_with_type = aux (start_structure features_reset "Cast") typ "CastType" (depth + 1) in
-          let feature' = set_interm features_with_type features.semantic.interm in
-          end_structure (aux feature' term "CastTerm" (depth + 1))
-        (* Hope and pray *)
-        | term -> warn term oterm; features
-      in
-      if depth == 3 then
-        (* break the maximal depth constraint*)
-        {features with structure = features.structure@["X"]}
-      else features
-    in
-    let features = aux init_features oterm "Root" 0 in
-    (* We use tail-recursive rev_map instead of map to avoid stack overflows on large proof states *)
-    let add_feature_kind features kind = List.map (fun feature -> kind, feature) features in
-    List.rev_map (fun (feat_kind, feats) -> feat_kind, String.concat "-" feats) (
-      (Struct, features.structure) ::
-      ((add_feature_kind features.semantic.acc Seman) @
-       (add_feature_kind features.vertical.acc Verti)))
-
-
-  let term_sexpr_to_complex_features2
+  let term_sexpr_to_complex_features
       ~gen_semantic:(seman_init, seman_comb, seman_add)
       ~gen_structural:(struct_init, struct_comb, struct_add)
       ~gen_vertical:(vert_init, vert_comb, vert_add)
@@ -446,47 +280,47 @@ module F (TS: TacticianStructures) = struct
        - `interm` is an intermediate list of list of features that are still being assembled
          invariant: `forall i ls, 0<i<=maxlength -> In ls (List.nth (i - 1)) -> List.length ls = i`
        - `acc`: accumulates features that are fully assembled *)
-    let add_atom atom ({ semantic2; store; _ } as features) =
+    let add_atom atom ({ semantic; store; _ } as features) =
       let atom = seman_init atom in
       (* `interm` contains term tree walks to maximal depth, maximal depth - 1,..., 1 *)
-      let semantic2 = [atom] :: List.map (List.map (seman_comb atom)) semantic2 in
+      let semantic = [atom] :: List.map (List.map (seman_comb atom)) semantic in
       (* Remove the last item to keep the maximal depth constraint.
         The length of `interm` = the maximal depth constraint.
         The initial `interm` is [[walk],[],...,[]]; thus, `removelast` will remove [] in the beginning *)
       { features with
-        semantic2 = removelast semantic2
-      ; store = List.fold_left seman_add store @@ List.flatten semantic2 }
+        semantic = removelast semantic
+      ; store = List.fold_left seman_add store @@ List.flatten semantic }
     in
-    let add_struct x ({ structure2; _ } as features) =
-      { features with structure2 = struct_comb x structure2 } in
-    let set_interm features semantic2 = { features with semantic2 } in
-    let set_walk features vertical2 = { features with vertical2 } in
+    let add_struct x ({ structure; _ } as features) =
+      { features with structure = struct_comb x structure } in
+    let set_interm features semantic = { features with semantic } in
+    let set_walk features vertical = { features with vertical } in
     let start = replicate [] (maxlength - 1) in
     let init_features =
-      { semantic2 = replicate [] (maxlength - 1)
-      ; structure2 = struct_init
-      ; vertical2 = 0, vert_init
+      { semantic = replicate [] (maxlength - 1)
+      ; structure = struct_init
+      ; vertical = 0, vert_init
       ; store = empty } in
-    let add_walk w ({ vertical2 = l, x; _ } as features) =
+    let add_walk w ({ vertical = l, x; _ } as features) =
       { features with
-        vertical2 = l+1, vert_comb w x } in
+        vertical = l+1, vert_comb w x } in
     let reset_interm features = set_interm features start in
-    let start_structure ({ structure2; _} as features) role =
+    let start_structure ({ structure; _} as features) role =
       { features with
-        structure2 =
-          struct_comb (TRole role) @@ struct_comb TOpenParen structure2 }
+        structure =
+          struct_comb (TRole role) @@ struct_comb TOpenParen structure }
     in
-    let end_structure ({ structure2; _ } as features) =
-       { features with structure2 = struct_comb TCloseParen structure2 }
+    let end_structure ({ structure; _ } as features) =
+       { features with structure = struct_comb TCloseParen structure }
     in
     let verti_atom atom features role =
-      if fst features.vertical2 == 1 then
+      if fst features.vertical == 1 then
         features
       else
         let atom_with_role = TAtom (atom, role) in
         { features with
           store =
-            vert_add (vert_comb atom_with_role @@ snd features.vertical2) features.store
+            vert_add (vert_comb atom_with_role @@ snd features.vertical) features.store
         }
     in
     let calculate_vertical_features (term : constr) role features =
@@ -508,7 +342,7 @@ module F (TS: TacticianStructures) = struct
       let features' = aux reset_features term role depth in
       reset_interm features'
     and aux_reset_fold features term_role_pairs depth =
-      let walk = features.vertical2 in
+      let walk = features.vertical in
       let next_level_depth = depth + 1 in
       List.fold_left (fun features' term_role_pair ->
           aux_reset features' term_role_pair next_level_depth walk) features term_role_pairs
@@ -566,7 +400,7 @@ module F (TS: TacticianStructures) = struct
           let features' = start_structure (add_atom (TConst p) features) TProj
           in end_structure (aux features' term TProjTerm (depth + 1))
         | App (head, args) ->
-          let walk = features.vertical2 in
+          let walk = features.vertical in
           let args = Array.to_list args in
           let arg_num = List.length args in
           let features_with_head = aux (start_structure features TApp) head TAppFun (depth + 1) in
@@ -575,7 +409,7 @@ module F (TS: TacticianStructures) = struct
               let features = set_walk features walk in
               let features_this_arg = aux features arg TAppArg (depth + 1) in
               (* We reset back to `interm` of `features_with_head_and_arg_num` for every arg *)
-              set_interm features_this_arg features_with_head_and_arg_num.semantic2)
+              set_interm features_this_arg features_with_head_and_arg_num.semantic)
               features_with_head_and_arg_num args
           in
           end_structure(reset_interm feature')
@@ -583,7 +417,7 @@ module F (TS: TacticianStructures) = struct
           (* We probably want to have the type of the cast, but isolated *)
           let features_reset = reset_interm features in
           let features_with_type = aux (start_structure features_reset TCast) typ TCastType (depth + 1) in
-          let feature' = set_interm features_with_type features.semantic2 in
+          let feature' = set_interm features_with_type features.semantic in
           end_structure (aux feature' term TCastTerm (depth + 1))
       in
       if depth == 3 then
@@ -592,16 +426,16 @@ module F (TS: TacticianStructures) = struct
       else features
     in
     let features = aux init_features oterm TRoot 0 in
-    struct_add features.structure2 features.store
+    struct_add features.structure features.store
 
   let inc x = function
     | None -> Some (x, 1)
     | Some (x, i) -> Some (x, i+1)
 
-  let term_sexpr_to_complex_strings2 prefix max_length acc term =
+  let term_sexpr_to_complex_strings prefix max_length acc term =
     let combine a b = if a = "" then b else a ^ "-" ^ b in
     let combine2 f a b = if b = "" then f a else b ^ "-" ^ f a in
-    term_sexpr_to_complex_features2
+    term_sexpr_to_complex_features
       ~gen_semantic:(semantic_token_to_string, combine,
                      (fun ls x -> CString.Map.update (prefix^x) (inc Seman) ls))
       ~gen_structural:("", combine2 structural_token_to_string,
@@ -611,10 +445,10 @@ module F (TS: TacticianStructures) = struct
       ~store_feat:acc
       max_length term
 
-  let term_sexpr_to_complex_ints2 prefix max_length acc term =
+  let term_sexpr_to_complex_ints prefix max_length acc term =
     let combine a b = Hashset.Combine.combine a b in
     let combine2 f a b = Hashset.Combine.combine (f a) b in
-    term_sexpr_to_complex_features2
+    term_sexpr_to_complex_features
       ~gen_semantic:(semantic_token_to_int, combine,
                      (fun ls x -> Int.Map.update (combine prefix x) (inc Seman) ls))
       ~gen_structural:(0, combine2 structural_token_to_int,
@@ -624,13 +458,13 @@ module F (TS: TacticianStructures) = struct
       ~store_feat:acc
       max_length term
 
-  let term_sexpr_to_complex_ints_no_kind2 prefix max_length acc term =
+  let term_sexpr_to_complex_ints_no_kind prefix max_length acc term =
     let combine a b = Hashset.Combine.combine a b in
     let combine2 f a b = Hashset.Combine.combine (f a) b in
     let inc = function
       | None -> Some 1
       | Some i -> Some (i+1) in
-    term_sexpr_to_complex_features2
+    term_sexpr_to_complex_features
       ~gen_semantic:(semantic_token_to_int, combine,
                      (fun ls x -> Int.Map.update (combine prefix x) inc ls))
       ~gen_structural:(0, combine2 structural_token_to_int,
@@ -640,26 +474,10 @@ module F (TS: TacticianStructures) = struct
       ~store_feat:acc
       max_length term
 
-  let proof_state_to_complex_features max_length ps =
+  let proof_state_to_complex_strings max_length ps =
     let hyps = proof_state_hypotheses ps in
     let goal = proof_state_goal ps in
-    let mkfeats t = term_sexpr_to_complex_features max_length (term_sexpr t) in
-    let hyp_id_typ_feats = List.map (function
-        | Named.Declaration.LocalAssum (id, typ) ->
-          (Names.Id.to_string id.binder_name), (sexpr_to_string (term_sexpr typ)), (mkfeats typ)
-        | Named.Declaration.LocalDef (id, term, typ) ->
-          (Names.Id.to_string id.binder_name),(sexpr_to_string (term_sexpr typ)), (mkfeats typ @ mkfeats term))
-        hyps in
-    let hyp_feats = List.map (fun (_, _, feats) -> feats) hyp_id_typ_feats in
-    let goal_feats = mkfeats goal in
-    (* seperate the goal from the local context *)
-    (List.map (fun (kind, feat) -> kind, "GOAL-"^ feat) goal_feats) @
-    (List.map (fun (kind, feat) -> kind, "HYPS-"^ feat) (List.flatten hyp_feats))
-
-  let proof_state_to_complex_strings2 max_length ps =
-    let hyps = proof_state_hypotheses ps in
-    let goal = proof_state_goal ps in
-    let mkfeats prefix t acc = term_sexpr_to_complex_strings2 prefix max_length acc (term_repr t) in
+    let mkfeats prefix t acc = term_sexpr_to_complex_strings prefix max_length acc (term_repr t) in
     let feats = List.fold_left (fun a b -> Named.Declaration.fold_constr (mkfeats "HYPS-") b a)
         CString.Map.empty hyps in
     let feats = mkfeats "GOAL-" goal feats in
@@ -670,13 +488,12 @@ module F (TS: TacticianStructures) = struct
              We should consider not adding feature counts to the featues itself. This is likely to be
              suboptimal for the model anyways. *)
     List.sort_uniq (fun (_kind1, feat1) (_kind2, feat2) -> String.compare feat1 feat2) feats_with_count
+  let proof_state_to_complex_strings ps = proof_state_to_complex_strings 2 ps
 
-  let proof_state_to_complex_strings2 ps = proof_state_to_complex_strings2 2 ps
-
-  let proof_state_to_complex_ints2 max_length ps =
+  let proof_state_to_complex_ints max_length ps =
     let hyps = proof_state_hypotheses ps in
     let goal = proof_state_goal ps in
-    let mkfeats prefix t acc = term_sexpr_to_complex_ints2 prefix max_length acc (term_repr t) in
+    let mkfeats prefix t acc = term_sexpr_to_complex_ints prefix max_length acc (term_repr t) in
     let feats = List.fold_left (fun a b -> Named.Declaration.fold_constr (mkfeats (Int.hash 2000)) b a)
         Int.Map.empty hyps in
     let feats = mkfeats (Int.hash 2001) goal feats in
@@ -687,13 +504,12 @@ module F (TS: TacticianStructures) = struct
              We should consider not adding feature counts to the featues itself. This is likely to be
              suboptimal for the model anyways. *)
     List.sort_uniq (fun (_kind1, feat1) (_kind2, feat2) -> Int.compare feat1 feat2) feats_with_count
+  let proof_state_to_complex_ints ps = proof_state_to_complex_ints 2 ps
 
-  let proof_state_to_complex_ints2 ps = proof_state_to_complex_ints2 2 ps
-
-  let proof_state_to_complex_ints_no_kind2 max_length ps =
+  let proof_state_to_complex_ints_no_kind max_length ps =
     let hyps = proof_state_hypotheses ps in
     let goal = proof_state_goal ps in
-    let mkfeats prefix t acc = term_sexpr_to_complex_ints_no_kind2 prefix max_length acc (term_repr t) in
+    let mkfeats prefix t acc = term_sexpr_to_complex_ints_no_kind prefix max_length acc (term_repr t) in
     let feats = List.fold_left (fun a b -> Named.Declaration.fold_constr (mkfeats (Int.hash 2000)) b a)
         Int.Map.empty hyps in
     let feats = mkfeats (Int.hash 2001) goal feats in
@@ -704,54 +520,27 @@ module F (TS: TacticianStructures) = struct
              We should consider not adding feature counts to the featues itself. This is likely to be
              suboptimal for the model anyways. *)
     List.sort_uniq Int.compare feats_with_count
-
-  let proof_state_to_complex_ints_no_kind2 ps = proof_state_to_complex_ints_no_kind2 2 ps
-
-  let count_dup l =
-    let sl = List.sort compare l in
-    match sl with
-    | [] -> []
-    | hd::tl ->
-      let acc,x,c = List.fold_left (fun (acc,x,c) y ->
-          if y = x then acc,x,c+1 else (x,c)::acc, y,1) ([],hd,1) tl in
-      (x,c)::acc
-
-  let proof_state_to_complex_ints ps =
-    let complex_feats = proof_state_to_complex_features 2 ps in
-    let feats_with_count_pair = count_dup complex_feats in
-    (* Tail recursive version of map, because these lists can get very large. *)
-    let feats_with_count = List.rev_map (fun ((kind, feat), count) -> kind, feat ^ "-" ^ (Stdlib.string_of_int count))
-        feats_with_count_pair in
-    (* print_endline (String.concat ", "  (List.map Stdlib.snd complex_feats)); *)
-    let feats = List.rev_map (fun (kind, feat) ->  kind, Hashtbl.hash feat) feats_with_count in
-    List.sort_uniq (fun (_kind1, feat1) (_kind2, feat2) -> Int.compare feat1 feat2) feats
-
-  let proof_state_to_complex_strings ps =
-    let complex_feats = proof_state_to_complex_features 2 ps in
-    let feats_with_count_pair = count_dup complex_feats in
-    (* Tail recursive version of map, because these lists can get very large. *)
-    let feats_with_count = List.rev_map (fun ((kind, feat), count) -> kind, feat ^ "-" ^ (Stdlib.string_of_int count))
-        feats_with_count_pair in
-    (* print_endline (String.concat ", "  (List.map Stdlib.snd complex_feats)); *)
-    List.sort_uniq (fun (_kind1, feat1) (_kind2, feat2) -> String.compare feat1 feat2) feats_with_count
-
-  let context_complex_features max_length ctx =
-    let mkfeats t = term_sexpr_to_complex_features max_length (term_sexpr t) in
-    context_map mkfeats mkfeats ctx
+  let proof_state_to_complex_ints_no_kind ps = proof_state_to_complex_ints_no_kind 2 ps
 
   let context_complex_ints ctx =
-    let ctx = context_complex_features 2 ctx in
-    let feats_with_count_pair = context_map count_dup count_dup ctx in
-    (* Tail recursive version of map, because these lists can get very large. *)
-    let feats_with_count_f pair = List.rev_map (fun ((feat_kind, feat), count) -> feat_kind, feat ^ "-" ^ (Stdlib.string_of_int count))
-        pair in
-    let feats_with_count = context_map feats_with_count_f feats_with_count_f feats_with_count_pair in
-    (* print_endline (String.concat ", "  (List.map Stdlib.snd feats_with_count)); *)
-    (* Tail recursive version of map, because these lists can get very large. *)
-    let feats f = List.rev_map (fun (feat_kind, feat) -> feat_kind, Hashtbl.hash feat) f in
-    let feats = context_map feats feats feats_with_count in
-    let sort f = List.sort_uniq (fun (_, feat1) (_, feat2) -> Int.compare feat1 feat2) f in
-    context_map sort sort feats
+    let mkfeats t = term_sexpr_to_complex_ints (Int.hash 2000) 2 Int.Map.empty (term_repr t) in
+    let ctx = context_map mkfeats mkfeats ctx in
+    let postprocess feats =
+      let feats = Int.Map.fold
+          (fun feat (kind, count) acc -> (kind, Hashset.Combine.combine feat count) :: acc)
+          feats [] in
+      List.sort_uniq (fun (_kind1, feat1) (_kind2, feat2) -> Int.compare feat1 feat2) feats in
+    context_map postprocess postprocess ctx
+
+  let context_complex_ints_no_kind ctx =
+    let mkfeats t = term_sexpr_to_complex_ints_no_kind (Int.hash 2000) 2 Int.Map.empty (term_repr t) in
+    let ctx = context_map mkfeats mkfeats ctx in
+    let postprocess feats =
+      let feats = Int.Map.fold
+          (fun feat count acc -> Hashset.Combine.combine feat count :: acc)
+          feats [] in
+      List.sort_uniq Int.compare feats in
+    context_map postprocess postprocess ctx
 
   let tfidf size freqs ls1 ls2 =
     let inter = intersect compare ls1 ls2 in
@@ -760,9 +549,6 @@ module F (TS: TacticianStructures) = struct
          (fun f -> Float.log ((Float.of_int (1 + size)) /.
                               (Float.of_int (1 + (Option.default 0 (Frequencies.find_opt f freqs))))))
          inter)
-
-  let remove_feat_kind l =
-    List.map snd l
 
   let manually_weighed_tfidf size freq ls1 ls2 =
     let inter = intersect (fun x y -> compare (snd x) y) ls1 ls2 in

--- a/src/features.ml
+++ b/src/features.ml
@@ -584,6 +584,15 @@ module F (TS: TacticianStructures) = struct
     let feats = List.rev_map (fun (kind, feat) ->  kind, Hashtbl.hash feat) feats_with_count in
     List.sort_uniq (fun (_kind1, feat1) (_kind2, feat2) -> Int.compare feat1 feat2) feats
 
+  let proof_state_to_complex_strings ps =
+    let complex_feats = proof_state_to_complex_features 2 ps in
+    let feats_with_count_pair = count_dup complex_feats in
+    (* Tail recursive version of map, because these lists can get very large. *)
+    let feats_with_count = List.rev_map (fun ((kind, feat), count) -> kind, feat ^ "-" ^ (Stdlib.string_of_int count))
+        feats_with_count_pair in
+    (* print_endline (String.concat ", "  (List.map Stdlib.snd complex_feats)); *)
+    List.sort_uniq (fun (_kind1, feat1) (_kind2, feat2) -> String.compare feat1 feat2) feats_with_count
+
   let proof_state_to_complex_ints2 ps =
     let complex_feats = proof_state_to_complex_features2 2 ps in
     let feats_with_count_pair = count_dup complex_feats in
@@ -593,6 +602,15 @@ module F (TS: TacticianStructures) = struct
     (* print_endline (String.concat ", "  (List.map Stdlib.snd complex_feats)); *)
     let feats = List.rev_map (fun (kind, feat) ->  kind, Hashtbl.hash feat) feats_with_count in
     List.sort_uniq (fun (_kind1, feat1) (_kind2, feat2) -> Int.compare feat1 feat2) feats
+
+  let proof_state_to_complex_strings2 ps =
+    let complex_feats = proof_state_to_complex_features2 2 ps in
+    let feats_with_count_pair = count_dup complex_feats in
+    (* Tail recursive version of map, because these lists can get very large. *)
+    let feats_with_count = List.rev_map (fun ((kind, feat), count) -> kind, feat ^ "-" ^ (Stdlib.string_of_int count))
+        feats_with_count_pair in
+    (* print_endline (String.concat ", "  (List.map Stdlib.snd complex_feats)); *)
+    List.sort_uniq (fun (_kind1, feat1) (_kind2, feat2) -> String.compare feat1 feat2) feats_with_count
 
   let context_complex_features max_length ctx =
     let mkfeats t = term_sexpr_to_complex_features max_length (term_sexpr t) in

--- a/src/features.ml
+++ b/src/features.ml
@@ -11,7 +11,7 @@ type 'a semantic_features = { interm: 'a list list; acc: 'a list}
 type 'a vertical_features = { walk: 'a; acc: 'a list}
 type ('a, 'b, 'c) features =
   { semantic : 'a semantic_features
-  ; structure : 'b list
+  ; structure : 'b
   ; vertical: 'c vertical_features }
 
 let global2s g =
@@ -136,10 +136,6 @@ module F (TS: TacticianStructures) = struct
   open LH
   open TS
 
-  let warn lterm oterm =
-    Feedback.msg_warning (Pp.str ("Tactician did not know how to handle something. Please report. "
-                                  ^ sexpr_to_string lterm ^ " : " ^sexpr_to_string oterm))
-
   let term_sexpr_to_simple_features
       ~gen_feat:(init, comb)
       ~store_feat:(empty, add)
@@ -242,15 +238,9 @@ module F (TS: TacticianStructures) = struct
     in
     rep_elem_aux [] n elem
 
-  let count_dup l =
-    let sl = List.sort compare l in
-    match sl with
-    | [] -> []
-    | hd::tl ->
-      let acc,x,c = List.fold_left (fun (acc,x,c) y ->
-          if y = x then acc,x,c+1 else (x,c)::acc, y,1) ([],hd,1) tl in
-      (x,c)::acc
-
+  let warn lterm oterm =
+    Feedback.msg_warning (Pp.str ("Tactician did not know how to handle something. Please report. "
+                                  ^ sexpr_to_string lterm ^ " : " ^sexpr_to_string oterm))
   let term_sexpr_to_complex_features maxlength oterm =
     let atomtypes = ["Evar"; "Rel"; "Construct"; "Ind"; "Const"; "Var"; "Int"; "Float"] in
     let is_atom nodetype = List.exists (String.equal nodetype) atomtypes in
@@ -574,6 +564,15 @@ module F (TS: TacticianStructures) = struct
       (* seperate the goal from the local context *)
       (List.map (fun (kind, feat) -> kind, "GOAL-"^ feat) goal_feats) @
       (List.map (fun (kind, feat) -> kind, "HYPS-"^ feat) (List.flatten hyp_feats))
+
+    let count_dup l =
+      let sl = List.sort compare l in
+      match sl with
+      | [] -> []
+      | hd::tl ->
+        let acc,x,c = List.fold_left (fun (acc,x,c) y ->
+            if y = x then acc,x,c+1 else (x,c)::acc, y,1) ([],hd,1) tl in
+        (x,c)::acc
 
   let proof_state_to_complex_ints ps =
     let complex_feats = proof_state_to_complex_features 2 ps in

--- a/src/features.ml
+++ b/src/features.ml
@@ -563,37 +563,37 @@ module F (TS: TacticianStructures) = struct
       ~store_feat:acc
       max_length term
 
-    let proof_state_to_complex_features max_length ps =
-      let hyps = proof_state_hypotheses ps in
-      let goal = proof_state_goal ps in
-      let mkfeats t = term_sexpr_to_complex_features max_length (term_sexpr t) in
-      let hyp_id_typ_feats = List.map (function
-          | Named.Declaration.LocalAssum (id, typ) ->
-            (Names.Id.to_string id.binder_name), (sexpr_to_string (term_sexpr typ)), (mkfeats typ)
-          | Named.Declaration.LocalDef (id, term, typ) ->
-            (Names.Id.to_string id.binder_name),(sexpr_to_string (term_sexpr typ)), (mkfeats typ @ mkfeats term))
-          hyps in
-      let hyp_feats = List.map (fun (_, _, feats) -> feats) hyp_id_typ_feats in
-      let goal_feats = mkfeats goal in
-      (* seperate the goal from the local context *)
-      (List.map (fun (kind, feat) -> kind, "GOAL-"^ feat) goal_feats) @
-      (List.map (fun (kind, feat) -> kind, "HYPS-"^ feat) (List.flatten hyp_feats))
+  let proof_state_to_complex_features max_length ps =
+    let hyps = proof_state_hypotheses ps in
+    let goal = proof_state_goal ps in
+    let mkfeats t = term_sexpr_to_complex_features max_length (term_sexpr t) in
+    let hyp_id_typ_feats = List.map (function
+        | Named.Declaration.LocalAssum (id, typ) ->
+          (Names.Id.to_string id.binder_name), (sexpr_to_string (term_sexpr typ)), (mkfeats typ)
+        | Named.Declaration.LocalDef (id, term, typ) ->
+          (Names.Id.to_string id.binder_name),(sexpr_to_string (term_sexpr typ)), (mkfeats typ @ mkfeats term))
+        hyps in
+    let hyp_feats = List.map (fun (_, _, feats) -> feats) hyp_id_typ_feats in
+    let goal_feats = mkfeats goal in
+    (* seperate the goal from the local context *)
+    (List.map (fun (kind, feat) -> kind, "GOAL-"^ feat) goal_feats) @
+    (List.map (fun (kind, feat) -> kind, "HYPS-"^ feat) (List.flatten hyp_feats))
 
-    let proof_state_to_complex_features2 max_length ps =
-      let hyps = proof_state_hypotheses ps in
-      let goal = proof_state_goal ps in
-      let mkfeats prefix t acc = term_sexpr_to_complex_features2 prefix max_length acc (term_repr t) in
-      let hyp_feats = List.fold_left (fun a b -> Named.Declaration.fold_constr (mkfeats "HYPS-") b a) [] hyps in
-      mkfeats "GOAL-" goal hyp_feats
+  let proof_state_to_complex_features2 max_length ps =
+    let hyps = proof_state_hypotheses ps in
+    let goal = proof_state_goal ps in
+    let mkfeats prefix t acc = term_sexpr_to_complex_features2 prefix max_length acc (term_repr t) in
+    let hyp_feats = List.fold_left (fun a b -> Named.Declaration.fold_constr (mkfeats "HYPS-") b a) [] hyps in
+    mkfeats "GOAL-" goal hyp_feats
 
-    let count_dup l =
-      let sl = List.sort compare l in
-      match sl with
-      | [] -> []
-      | hd::tl ->
-        let acc,x,c = List.fold_left (fun (acc,x,c) y ->
-            if y = x then acc,x,c+1 else (x,c)::acc, y,1) ([],hd,1) tl in
-        (x,c)::acc
+  let count_dup l =
+    let sl = List.sort compare l in
+    match sl with
+    | [] -> []
+    | hd::tl ->
+      let acc,x,c = List.fold_left (fun (acc,x,c) y ->
+          if y = x then acc,x,c+1 else (x,c)::acc, y,1) ([],hd,1) tl in
+      (x,c)::acc
 
   let proof_state_to_complex_ints ps =
     let complex_feats = proof_state_to_complex_features 2 ps in

--- a/src/features.ml
+++ b/src/features.ml
@@ -85,7 +85,7 @@ let semantic_token_to_string = function
   | TEvar -> "E"
   | TConstruct c -> constructor2s c
   | TInd i -> inductive2s i
-  | TVar id -> id2s id
+  | TVar id -> "$" ^ id2s id
   | TConst c -> constant2s c
   | TInt n -> "i" ^ Uint63.to_string n
   | TFloat n -> "f" ^ Float64.to_string n
@@ -255,9 +255,9 @@ module F (TS: TacticianStructures) = struct
     let atom_to_string atomtype content = match atomtype, content with
       | "Rel", _ -> "R"
       | "Evar", (Leaf _ :: _) -> "E"
+      | "Var", Leaf c :: _ -> "$" ^ c
       | "Construct", Leaf c :: _
       | "Ind", Leaf c :: _
-      | "Var", Leaf c :: _
       | "Const", Leaf c :: _ -> c
       | "Int", Leaf c :: _ -> "i" ^ c
       | "Float", Leaf c :: _ -> "f" ^ c

--- a/src/features.ml
+++ b/src/features.ml
@@ -123,23 +123,6 @@ module F (TS: TacticianStructures) = struct
     in
     snd @@ aux (start, empty) oterm
 
-  let disting_hyps_goal ls symbol =
-    (* We use tail-recursive rev_map instead of map to avoid stack overflows on large proof states *)
-    List.rev_map (fun (feat_kind, feat) -> feat_kind, symbol ^ feat) ls
-
-  let get_top_interm interm =
-    let flat_interm = List.flatten interm in
-    if flat_interm <> [] then
-      List.nth flat_interm (List.length flat_interm -1)
-    else
-      []
-    (* List.hd (List.rev flat_interm)  *)
-  let rep_elem n elem =
-    let rec rep_elem_aux acc n elem =
-      if n = 0 then acc else rep_elem_aux (elem :: acc) (n-1) elem
-    in
-    rep_elem_aux [] n elem
-
   let proof_state_to_simple_features ~gen_feat ~store_feat:(acc, add) max_length ps =
     let hyps = proof_state_hypotheses ps in
     let goal = proof_state_goal ps in
@@ -173,6 +156,12 @@ module F (TS: TacticianStructures) = struct
         ~store_feat:(CString.Set.empty, (fun a b -> CString.Set.add b a))
         2 ps in
     CString.Set.elements feats
+
+  let rep_elem n elem =
+    let rec rep_elem_aux acc n elem =
+      if n = 0 then acc else rep_elem_aux (elem :: acc) (n-1) elem
+    in
+    rep_elem_aux [] n elem
 
   let count_dup l =
     let sl = List.sort compare l in

--- a/src/features.ml
+++ b/src/features.ml
@@ -365,7 +365,7 @@ module F (TS: TacticianStructures) = struct
     List.fold_left (+.) 0.
       (List.map
          (fun f -> Float.log ((Float.of_int (1 + size)) /.
-                              (Float.of_int (1 + (default 0 (Frequencies.find_opt f freqs))))))
+                              (Float.of_int (1 + (Option.default 0 (Frequencies.find_opt f freqs))))))
          inter)
 
   let remove_feat_kind l =
@@ -375,7 +375,7 @@ module F (TS: TacticianStructures) = struct
     let inter = intersect (fun x y -> compare (snd x) y) ls1 ls2 in
     let similarity_for_one_feat feat =
       Float.log ((Float.of_int (1 + size)) /.
-                 (Float.of_int (1 + (default 0 (Frequencies.find_opt feat freq)))))
+                 (Float.of_int (1 + (Option.default 0 (Frequencies.find_opt feat freq)))))
     in
     List.fold_left (+.) 0.
       (List.map

--- a/src/features.ml
+++ b/src/features.ml
@@ -483,30 +483,28 @@ module F (TS: TacticianStructures) = struct
 
         (* Recursion for grammar we don't handle *)
         | LetIn (_, body1, typ, body2) ->
-          let roles = [TLetVarBody; TLetVarType; TLetBody] in
-          end_structure (aux_reset_fold (start_structure features TLetIn)
-                           (List.combine [body1; typ; body2] roles) depth)
+          let cont = [body1, TLetVarBody; typ, TLetVarType; body2, TLetBody] in
+          end_structure (aux_reset_fold (start_structure features TLetIn) cont depth)
         | Case (_, term, typ, cases) ->
           let cases = Array.to_list cases in
-          let roles = ([TMatchTerm; TMatchTermType] @ (rep_elem (List.length cases) TCase)) in
-          end_structure (aux_reset_fold (start_structure features TCase)
-                           (List.combine (term::typ::cases) roles) depth)
+          let cont = [term, TMatchTerm; typ, TMatchTermType] @ (List.map (fun c -> c, TCase) cases) in
+          end_structure (aux_reset_fold (start_structure features TCase) cont depth)
         | Fix (_, (_, types, terms)) ->
           let terms = Array.to_list terms in
           let types = Array.to_list types in
-          let roles = (rep_elem (List.length terms) TFixTerm) @ (rep_elem (List.length types) TFixType) in
-          end_structure (aux_reset_fold (start_structure features TFix) (List.combine (terms @ types) roles) depth)
+          let cont = (List.map (fun c -> c, TFixTerm) terms) @ (List.map (fun c -> c, TFixType) types) in
+          end_structure (aux_reset_fold (start_structure features TFix) cont depth)
         | CoFix (_, (_, types, terms)) ->
           let terms = Array.to_list terms in
           let types = Array.to_list types in
-          let roles = (rep_elem (List.length terms) TCoFixTerm) @ (rep_elem (List.length types) TCoFixType) in
-          end_structure (aux_reset_fold (start_structure features TCoFix) (List.combine (terms @ types) roles) depth)
+          let cont = (List.map (fun c -> c, TCoFixTerm) terms) @ (List.map (fun c -> c, TCoFixType) types) in
+          end_structure (aux_reset_fold (start_structure features TCoFix) cont depth)
         | Prod (_, typ, body) ->
-          let roles = [TProdType; TProdBody] in
-          end_structure(aux_reset_fold (start_structure features TProd) (List.combine [typ; body] roles) depth)
+          let cont = [typ, TProdType; body, TProdBody] in
+          end_structure(aux_reset_fold (start_structure features TProd) cont depth)
         | Lambda (_, typ, body) ->
-          let roles = [TLambdaType; TLambdaBody] in
-          end_structure(aux_reset_fold (start_structure features TLambda) (List.combine [typ; body] roles) depth)
+          let cont = [typ, TLambdaType; body, TLambdaBody] in
+          end_structure(aux_reset_fold (start_structure features TLambda) cont depth)
 
         (* The golden path *)
         | Proj (p, term) ->

--- a/src/features.ml
+++ b/src/features.ml
@@ -675,7 +675,7 @@ module F (TS: TacticianStructures) = struct
       (List.map
          (fun (feat_kind, f) ->
             if feat_kind == Struct
-            then (Float.of_int(1) *. similarity_for_one_feat f)
+            then (1. *. similarity_for_one_feat f)
             else similarity_for_one_feat f)
          inter)
 

--- a/src/features.ml
+++ b/src/features.ml
@@ -690,6 +690,23 @@ module F (TS: TacticianStructures) = struct
 
   let proof_state_to_complex_ints2 ps = proof_state_to_complex_ints2 2 ps
 
+  let proof_state_to_complex_ints_no_kind2 max_length ps =
+    let hyps = proof_state_hypotheses ps in
+    let goal = proof_state_goal ps in
+    let mkfeats prefix t acc = term_sexpr_to_complex_ints_no_kind2 prefix max_length acc (term_repr t) in
+    let feats = List.fold_left (fun a b -> Named.Declaration.fold_constr (mkfeats (Int.hash 2000)) b a)
+        Int.Map.empty hyps in
+    let feats = mkfeats (Int.hash 2001) goal feats in
+    let feats_with_count = Int.Map.fold
+        (fun feat count acc -> Hashset.Combine.combine feat count :: acc)
+        feats [] in
+    (* TODO: In the current fomulation, this resorting is needed. However, this is rather expensive.
+             We should consider not adding feature counts to the featues itself. This is likely to be
+             suboptimal for the model anyways. *)
+    List.sort_uniq Int.compare feats_with_count
+
+  let proof_state_to_complex_ints_no_kind2 ps = proof_state_to_complex_ints_no_kind2 2 ps
+
   let count_dup l =
     let sl = List.sort compare l in
     match sl with

--- a/src/learner_helper.ml
+++ b/src/learner_helper.ml
@@ -107,6 +107,4 @@ module L (TS: TacticianStructures) = struct
         ) in
     intersect l1 l2
 
-  let default d opt = match opt with | None -> d | Some x -> x
-
 end

--- a/src/lshf_learner.ml
+++ b/src/lshf_learner.ml
@@ -168,5 +168,5 @@ module ComplexLSHF : TacticianOnlineLearnerType =
     let predict db f = predict db f proof_state_to_complex_ints (List.map snd) manually_weighed_tfidf
   end
 
-(* let () = register_online_learner "SimpleLSHF" (module SimpleLSHF) *)
+let () = register_online_learner "SimpleLSHF" (module SimpleLSHF)
 (* let () = register_online_learner "ComplexLSHF" (module ComplexLSHF) *)

--- a/src/lshf_learner.ml
+++ b/src/lshf_learner.ml
@@ -164,8 +164,8 @@ module ComplexLSHF : TacticianOnlineLearnerType =
     module FH = F(TS)
     open FH
     let learn db _status outcomes tac = learn db _status outcomes tac
-        (fun x -> remove_feat_kind @@ proof_state_to_complex_ints x)
-    let predict db f = predict db f proof_state_to_complex_ints remove_feat_kind manually_weighed_tfidf
+        proof_state_to_complex_ints_no_kind
+    let predict db f = predict db f proof_state_to_complex_ints (List.map snd) manually_weighed_tfidf
   end
 
 (* let () = register_online_learner "SimpleLSHF" (module SimpleLSHF) *)

--- a/src/lshf_learner.ml
+++ b/src/lshf_learner.ml
@@ -168,5 +168,5 @@ module ComplexLSHF : TacticianOnlineLearnerType =
     let predict db f = predict db f proof_state_to_complex_ints (List.map snd) manually_weighed_tfidf
   end
 
-let () = register_online_learner "SimpleLSHF" (module SimpleLSHF)
-(* let () = register_online_learner "ComplexLSHF" (module ComplexLSHF) *)
+(* let () = register_online_learner "SimpleLSHF" (module SimpleLSHF) *)
+let () = register_online_learner "ComplexLSHF" (module ComplexLSHF)

--- a/src/lshf_learner.ml
+++ b/src/lshf_learner.ml
@@ -169,4 +169,4 @@ module ComplexLSHF : TacticianOnlineLearnerType =
   end
 
 (* let () = register_online_learner "SimpleLSHF" (module SimpleLSHF) *)
-let () = register_online_learner "ComplexLSHF" (module ComplexLSHF)
+(* let () = register_online_learner "ComplexLSHF" (module ComplexLSHF) *)

--- a/src/lshf_learner.ml
+++ b/src/lshf_learner.ml
@@ -121,7 +121,7 @@ module LSHF =
     let feats = to_feats b in
     let frequencies = List.fold_left
         (fun freq f ->
-           Frequencies.update f (fun y -> Some ((default 0 y) + 1)) freq)
+           Frequencies.update f (fun y -> Some ((Option.default 0 y) + 1)) freq)
         db.frequencies
         feats in
     (* TODO: Length needs to be adjusted if we want to use multisets  *)

--- a/src/naiveknn_learner.ml
+++ b/src/naiveknn_learner.ml
@@ -81,5 +81,5 @@ module ComplexNaiveKnn : TacticianOnlineLearnerType = functor (TS : TacticianStr
 
 end
 
-(* let () = register_online_learner "simple-naive-knn" (module SimpleNaiveKnn) *)
+let () = register_online_learner "simple-naive-knn" (module SimpleNaiveKnn)
 (* let () = register_online_learner "complex-naive-knn" (module ComplexNaiveKnn) *)

--- a/src/naiveknn_learner.ml
+++ b/src/naiveknn_learner.ml
@@ -117,5 +117,5 @@ module ComplexNaiveKnn : TacticianOnlineLearnerType = functor (TS : TacticianStr
 
 end
 
-let () = register_online_learner "simple-naive-knn" (module SimpleNaiveKnn)
-(* let () = register_online_learner "complex-naive-knn" (module ComplexNaiveKnn) *)
+(* let () = register_online_learner "simple-naive-knn" (module SimpleNaiveKnn) *)
+let () = register_online_learner "complex-naive-knn" (module ComplexNaiveKnn)

--- a/src/naiveknn_learner.ml
+++ b/src/naiveknn_learner.ml
@@ -2,6 +2,48 @@ open Tactic_learner
 open Learner_helper
 open Features
 
+module CircularQueue : sig
+  type 'a t
+  val empty : int -> 'a t
+  val add : 'a -> 'a t -> 'a option * 'a t
+  val to_list_map : ('a -> 'b) -> 'a t -> 'b list
+  val size : 'a t -> int
+  val max : 'a t -> int
+end = struct
+  type 'a t =
+    { max      : int
+    ; size     : int
+    ; incoming : 'a list
+    ; outgoing : 'a list }
+
+  let empty max = { size = 0; max; incoming = []; outgoing = [] }
+
+  let head_tail ls = List.hd ls, List.tl ls
+
+  let add x { max; size; incoming; outgoing } =
+    if size < max then begin
+      assert (outgoing = []);
+      None, { max; size = size + 1; incoming = x::incoming; outgoing }
+      end
+    else begin
+      assert (size = max);
+      match outgoing with
+      | [] ->
+        let out, outgoing = head_tail @@ List.rev (x::incoming) in
+        Some out, { max; size; incoming = []; outgoing }
+      | out::outgoing ->
+        Some out, { max; size; incoming = x::incoming; outgoing }
+    end
+
+  let to_list_map f { incoming; outgoing; _ } =
+    let tail = List.fold_right (fun x -> List.cons (f x)) outgoing [] in
+    List.fold_left (fun ls x -> List.cons (f x) ls) tail incoming
+
+  let size { size; _ } = size
+  let max { max; _ } = max
+
+end
+
 module NaiveKnn = functor (TS : TacticianStructures) -> struct
   module LH = L(TS)
   open TS
@@ -12,47 +54,41 @@ module NaiveKnn = functor (TS : TacticianStructures) -> struct
       obj      : tactic
     }
   type database =
-    { entries     : db_entry list
-    ; length      : int
+    { entries     : db_entry CircularQueue.t
     ; frequencies : int Frequencies.t}
 
   type model = database
 
-  let empty () = {entries = []; length = 0; frequencies = Frequencies.empty}
+  let max = 1000
+  let empty () = {entries = CircularQueue.empty max; frequencies = Frequencies.empty}
 
-  let rec deletelast = function
-    | [] -> assert false
-    | [x] -> (x.features, [])
-    | x::ls' -> let (last, lsn) = deletelast ls' in (last, x::lsn)
-
-  let add db b obj to_feat =
-    let feats = to_feat b in
-    let comb = {features = feats; obj = obj} in
-    let newfreq = List.fold_left
+  let add { entries; frequencies } b obj to_feat =
+    let features = to_feat b in
+    let comb = { features; obj } in
+    let frequencies = List.fold_left
         (fun freq f ->
            Frequencies.update f (fun y -> Some ((default 0 y) + 1)) freq)
-        db.frequencies
-        feats in
-    let max = 1000 in
-    let last, purgedentries = if db.length >= max then deletelast db.entries else ([], db.entries) in
-    let newfreq = List.fold_left
-        (fun freq f ->
-           Frequencies.update f (fun y -> Some ((default 1 y) - 1)) freq)
-        newfreq
-        last in
-    (* TODO: Length needs to be adjusted if we want to use multisets  *)
-    let l = if db.length >= max then db.length else db.length + 1 in
-    {entries = comb::purgedentries; length = l; frequencies = newfreq}
+        frequencies
+        features in
+    let out, entries = CircularQueue.add comb entries in
+    let frequencies = Option.cata (fun out ->
+        List.fold_left
+          (fun freq f ->
+             Frequencies.update f (fun y -> Some ((default 1 y) - 1)) freq)
+          frequencies out.features)
+        frequencies out in
+    { entries; frequencies }
 
   let learn db _status outcomes tac to_feat =
     List.fold_left (fun db out -> add db out.before tac to_feat) db outcomes
 
-  let predict db f to_feat tfidf =
+  let predict { entries; frequencies } f to_feat tfidf =
     if f = [] then IStream.empty else
       let feats = to_feat (List.hd f).state in
-      let tdidfs = List.map
-          (fun ent -> let x = tfidf db.length db.frequencies feats ent.features in (x, ent.obj))
-          db.entries in
+      let length = CircularQueue.size entries in
+      let tdidfs = CircularQueue.to_list_map
+          (fun ent -> let x = tfidf length frequencies feats ent.features in (x, ent.obj))
+          entries in
       let out = remove_dups_and_sort tdidfs in
       let out = List.map (fun (a, c) -> { confidence = a; focus = 0; tactic = c }) out in
       IStream.of_list out

--- a/src/naiveknn_learner.ml
+++ b/src/naiveknn_learner.ml
@@ -67,14 +67,14 @@ module NaiveKnn = functor (TS : TacticianStructures) -> struct
     let comb = { features; obj } in
     let frequencies = List.fold_left
         (fun freq f ->
-           Frequencies.update f (fun y -> Some ((default 0 y) + 1)) freq)
+           Frequencies.update f (fun y -> Some ((Option.default 0 y) + 1)) freq)
         frequencies
         features in
     let out, entries = CircularQueue.add comb entries in
     let frequencies = Option.cata (fun out ->
         List.fold_left
           (fun freq f ->
-             Frequencies.update f (fun y -> Some ((default 1 y) - 1)) freq)
+             Frequencies.update f (fun y -> Some ((Option.default 1 y) - 1)) freq)
           frequencies out.features)
         frequencies out in
     { entries; frequencies }

--- a/src/naiveknn_learner.ml
+++ b/src/naiveknn_learner.ml
@@ -112,7 +112,7 @@ module ComplexNaiveKnn : TacticianOnlineLearnerType = functor (TS : TacticianStr
   module FH = F(TS)
   open FH
   let learn db _status outcomes tac = learn db _status outcomes tac
-      (fun x -> remove_feat_kind @@ proof_state_to_complex_ints x)
+      proof_state_to_complex_ints_no_kind
   let predict db f = predict db f proof_state_to_complex_ints manually_weighed_tfidf
 
 end

--- a/src/naiveknn_learner.ml
+++ b/src/naiveknn_learner.ml
@@ -118,4 +118,4 @@ module ComplexNaiveKnn : TacticianOnlineLearnerType = functor (TS : TacticianStr
 end
 
 (* let () = register_online_learner "simple-naive-knn" (module SimpleNaiveKnn) *)
-let () = register_online_learner "complex-naive-knn" (module ComplexNaiveKnn)
+(* let () = register_online_learner "complex-naive-knn" (module ComplexNaiveKnn) *)

--- a/src/naiveknn_subst_learner.ml
+++ b/src/naiveknn_subst_learner.ml
@@ -152,10 +152,10 @@ module ComplexNaiveSubstKnn : TacticianOnlineLearnerType = functor (TS : Tactici
   open FH
   open LH
   let learn db _status outcomes tac = learn db _status outcomes tac
-      (fun x -> remove_feat_kind @@ proof_state_to_complex_ints x)
+      proof_state_to_complex_ints_no_kind
       context_complex_ints
   let predict db f = predict db f proof_state_to_complex_ints
-      (fun x -> context_map remove_feat_kind remove_feat_kind @@ context_complex_ints x)
+      context_complex_ints_no_kind
       manually_weighed_tfidf
 
 end

--- a/src/naiveknn_subst_learner.ml
+++ b/src/naiveknn_subst_learner.ml
@@ -60,14 +60,14 @@ module NaiveKnnSubst (SF : sig type second_feat end) = functor (TS : TacticianSt
       let comb = {features = feats; context = ctx; obj = obj; substituted_hash = sh} in
       let newfreq = List.fold_left
           (fun freq f ->
-             Frequencies.update f (fun y -> Some ((default 0 y) + 1)) freq)
+             Frequencies.update f (fun y -> Some ((Option.default 0 y) + 1)) freq)
           db.frequencies
           feats in
       let max = 1000 in
       let last, purgedentries = if db.length >= max then deletelast db.entries else ([], db.entries) in
       let newfreq = List.fold_left
           (fun freq f ->
-             Frequencies.update f (fun y -> Some ((default 1 y) - 1)) freq)
+             Frequencies.update f (fun y -> Some ((Option.default 1 y) - 1)) freq)
           newfreq
           last in
       (* TODO: Length needs to be adjusted if we want to use multisets  *)

--- a/src/tactic_learner.mli
+++ b/src/tactic_learner.mli
@@ -8,7 +8,7 @@ type id = Id.t
 module IdMap : Map.S with type key = Id.t
 type id_map = Id.t IdMap.t
 
-type sexpr = Node of sexpr list | Leaf of string
+type sexpr = Sexpr.sexpr = Node of sexpr list | Leaf of string
 
 module type TacticianStructures = sig
   type term


### PR DESCRIPTION
This is a major rewrite of the features. The goal is to keep the feature generation fully equivalent to the previous behavior, but faster. This succeeded with the following caveats:

1. The features have changed a tiny bit, the sense that variables `X` now have a dollar sign prefixed to it: `$X`. This is to prevent them from colliding with the structural end-of-sequence sign `X`.
2. While the textual representation has remained the same (modulo point (1)), the integer representation has changed due to a new way of calculating the hashes.

This refactoring means a ~2x speedup for the simple features and a ~5x speedup for the complex features. I measured this by how fast we can load the `Lia` library:
```
Simple:

Lia no features:    Finished transaction in 0.398 secs (0.298u,0.099s) (successful)

Lia old features:   Finished transaction in 2.278 secs (2.229u,0.048s) (successful)
Lia new features:   Finished transaction in 1.241 secs (1.187u,0.054s) (successful)
Lia folding:        Finished transaction in 1.138 secs (1.041u,0.096s) (successful)
Lia set:            Finished transaction in 1.135 secs (1.071u,0.063s) (successful)
Lia new no sorting: Finished transaction in 0.903 secs (0.826u,0.076s) (successful) (hypothetical)

Complex:

Lia no features:              Finished transaction in 0.338 secs (0.297u,0.04s) (successful)

Lia old string features:      Finished transaction in 11.028 secs (10.896u,0.129s) (successful)
Lia new string features:      Finished transaction in 6.07 secs (5.478u,0.579s) (successful)
Lia old int features:         Finished transaction in 11.362 secs (11.249u,0.109s) (successful)
Lia new int features:         Finished transaction in 2.315 secs (2.232u,0.081s) (successful)
Lia old int no-kind features: Finished transaction in 11.292 secs (11.156u,0.132s) (successful)
Lia new int no-kind features: Finished transaction in 2.266 secs (2.196u,0.069s) (successful)
Lia new int no-kind no-sort:  Finished transaction in 2.126 secs (2.061u,0.064s) (successful) (hypothetical)
```
Benchmarks that measure the impact on the models performance are still underway.

This PR goes a long way toward resolving #32. There is probably still some performance to be squeezed out though.

@Zhang-Liao  any comments?