### PR TITLE
Adapt to Coq PR #19404: an algebra of types for the instances of notation variables

### DIFF
--- a/src/map_all_the_things.ml
+++ b/src/map_all_the_things.ml
@@ -325,11 +325,10 @@ module MakeMapper (M: MapDef) = struct
     | CPatOr pas ->
       CPatOr (OList.map cases_pattern_expr_id_map pas)
     (* kcas introduced in 8.19. Right now we do nothing with it here. *)
-    | CPatNotation (ns, n, (cas1, cas2, kcas), cas3) ->
-      let cas1 = OList.map cases_pattern_expr_id_map cas1 in
-      let cas2 = OList.map (OList.map cases_pattern_expr_id_map) cas2 in
+    | CPatNotation (ns, n, subst, cas3) ->
+      let subst = OList.map (notation_arg_type_map f) subst in
       let cas3 = OList.map cases_pattern_expr_id_map cas3 in
-      CPatNotation (ns, n, (cas1, cas2, kcas), cas3)
+      CPatNotation (ns, n, subst, cas3)
     | CPatPrim _ -> case
     | CPatRecord xs ->
       let xs = OList.map (fun (qu, ca) ->
@@ -343,6 +342,18 @@ module MakeMapper (M: MapDef) = struct
       CPatCast (cases_pattern_expr_id_map c1, c2)
   and cases_pattern_expr_id_map f c =
     CAst.map (cases_pattern_expr_r_id_map f) c
+  and kinded_cases_pattern_expr_id_map f (c, bk) =
+    let c = cases_pattern_expr_id_map f c in
+    (c, bk)
+  and notation_arg_kind_map f = function
+    | NtnTypeArgConstr a -> NtnTypeArgConstr a
+    | NtnTypeArgPattern pat -> NtnTypeArgPattern (kinded_cases_pattern_expr_id_map f pat)
+    | NtnTypeArgBinders binders -> NtnTypeArgBinders binders
+  and notation_arg_type_map f = function
+    | NtnTypeArg a -> NtnTypeArg (notation_arg_kind_map f a)
+    | NtnTypeArgList l -> NtnTypeArgList (OList.map (notation_arg_type_map f) l)
+    | NtnTypeArgTuple l -> NtnTypeArgTuple (OList.map (notation_arg_type_map f) l)
+
   (* Relevance info introduced in 8.20. Do nothing right now. *)
   let local_binder_expr_id_map f : local_binder_expr -> local_binder_expr = function
     | CLocalAssum (lis, r, bk, c) ->

--- a/src/map_all_the_things.ml
+++ b/src/map_all_the_things.ml
@@ -877,16 +877,12 @@ module MakeMapper (M: MapDef) = struct
       let+ pas = List.map cases_pattern_expr_map pas in
       let pas, bndrs = OList.split pas in
       CPatOr pas, OList.concat bndrs
-    | CPatNotation (ns, n, (cas1, cas2, ps), cas3) ->
-      let+ cas1 = List.map cases_pattern_expr_map cas1
-      and+ cas2 = List.map (List.map cases_pattern_expr_map) cas2
-      and+ ps = List.map (kinded_cases_pattern_expr_map m r) ps
+    | CPatNotation (ns, n, subst, cas3) ->
+      let+ subst = List.map (notation_arg_type_map m r) subst
       and+ cas3 = List.map cases_pattern_expr_map cas3 in
-      let cas1, bndrs1 = OList.split cas1 in
-      let cas2, bndrs2 = OList.split (OList.map OList.split cas2) in
-      let ps, bndrs = OList.split ps in
+      let subst, bndrs = OList.split subst in
       let cas3, bndrs3 = OList.split cas3 in
-      CPatNotation (ns, n, (cas1, cas2, ps), cas3), OList.concat (bndrs1 @ OList.concat bndrs2 @  bndrs @ bndrs3)
+      CPatNotation (ns, n, subst, cas3), OList.concat (bndrs @ bndrs3)
     | CPatPrim _ -> return (case, [])
     | CPatRecord xs ->
       let+ xs = List.map (fun (qu, ca) ->
@@ -1037,15 +1033,11 @@ module MakeMapper (M: MapDef) = struct
       let+ c = constr_expr_map c
       and+ c2 = constr_expr_map c2 in
       CCast (c, k, c2)
-    | CNotation (ns, n, (cs1, cs2, ps, bs)) ->
+    | CNotation (ns, n, subst) ->
       (* TODO: Having the binders in the right location here seems very complicated *)
-      let+ cs1 = List.map constr_expr_map cs1
-      and+ cs2 = List.map (List.map constr_expr_map) cs2
-      and+ ps = List.map (kinded_cases_pattern_expr_map m r) ps
-      and+ bs = List.map (List.map (local_binder_expr_map m r)) bs in
-      let ps, _ = OList.split ps in
-      let bs, _ = OList.split (OList.map OList.split bs) in
-      CNotation (ns, n, (cs1, cs2, ps, bs))
+      let+ subst = List.map (notation_arg_type_map m r) subst in
+      let subst, _ = OList.split subst in
+      CNotation (ns, n, subst)
     | CGeneralization (bk, c) ->
       let+ c = constr_expr_map c in
       CGeneralization (bk, c)
@@ -1107,6 +1099,23 @@ module MakeMapper (M: MapDef) = struct
   and recursion_order_expr m r x = mcast m (recursion_order_expr_r m r) x
   and constr_expr_map (m : mapper) r c : constr_expr t =
     mcast m (constr_expr_r_map m r) c
+  and notation_arg_kind_map m r = function
+    | NtnTypeArgConstr a -> let+ a = constr_expr_map m r a in NtnTypeArgConstr a, []
+    | NtnTypeArgPattern pat -> let+ pat, bndrs = kinded_cases_pattern_expr_map m r pat in NtnTypeArgPattern pat, bndrs
+    | NtnTypeArgBinders binders ->
+      let+ binders = List.map (local_binder_expr_map m r) binders in
+      let binders, _ = OList.split binders in
+      NtnTypeArgBinders binders, []
+  and notation_arg_type_map m r = function
+    | NtnTypeArg a -> let+ a, bndrs = notation_arg_kind_map m r a in NtnTypeArg a, bndrs
+    | NtnTypeArgList l ->
+      let+ l = List.map (notation_arg_type_map m r) l in
+      let l, bndrs = OList.split l in
+      NtnTypeArgList l, OList.concat bndrs
+    | NtnTypeArgTuple l ->
+      let+ l = List.map (notation_arg_type_map m r) l in
+      let l, bndrs = OList.split l in
+      NtnTypeArgTuple l, OList.concat bndrs
 
   and constr_pattern_map m pat' =
     let constr_pattern_map = constr_pattern_map m in


### PR DESCRIPTION
This PR is in preparation of coq/coq#19404 which introduces an algebra of types for the instances of notation variables.

As observed in the code, there is no way to statically know what is the binding structure provided by a notation (one needs  first to disambiguate the notation and get its interpretation).

The situation with the proposed PR is not better (nor a priori worse) than before: the potential binders are dropped in `CNotation` and assumed to be binders in `CPatNotation`. (Note a little improvement: in `CPatNotation`, we know that potential binders are only in the instances of type `Pattern`.)

Otherwise, to be merged synchronously.