### PR TITLE
Adapt to Rocq dev ssreflect and cmdliner 2.x

### DIFF
--- a/coq-shim/dune
+++ b/coq-shim/dune
@@ -60,6 +60,8 @@
  (modules ("tactician") coq_shim)
  (libraries
    unix
+   cmdliner
+   rresult
    opam-client
    dune-site
    bos

--- a/src/map_ssr_witnesses.ml
+++ b/src/map_ssr_witnesses.ml
@@ -121,16 +121,16 @@ module SSRMap (M : MapDef) = struct
       let+ i = f i
       and+ t = g t in
       In_X_In_T (i, t)
-    | E_In_X_In_T (t1, i, t2) ->
+    | E_In_X_In_T (t1, (i, t2)) ->
       let+ t1 = g t1
       and+ i = f i
       and+ t2 = g t2 in
-      E_In_X_In_T (t1, i, t2)
-    | E_As_X_In_T (t1, i, t2) ->
+      E_In_X_In_T (t1, (i, t2))
+    | E_As_X_In_T (t1, (i, t2)) ->
       let+ t1 = g t1
       and+ i = f i
       and+ t2 = g t2 in
-      E_As_X_In_T (t1, i, t2)
+      E_As_X_In_T (t1, (i, t2))
 
   let rpattern_map m (p : rpattern) =
     ssrpattern_map (cpattern_map m) (cpattern_map m) p


### PR DESCRIPTION
Rocq dev changed `E_In_X_In_T` and `E_As_X_In_T` from flat three-argument constructors to a term paired with an `inpat`. Adapt Tactician’s ssreflect witness mapper to the new representation.

Also declare the `cmdliner` and `rresult` Dune libraries explicitly. Recent opam-client no longer makes these modules available transitively, causing the generated `coq-shim/tactician.ml` to fail with `Unbound module Cmdliner`.

Tested with:

```console
opam exec --switch=rocq-dev-testing -- dune build -j 8 -p coq-tactician @install
```

This draft reuses the compatibility commit prepared on `theorem-labs:claude/rocq-dev-compat`, exposed under a separate Codex branch to avoid modifying that branch.

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*